### PR TITLE
Added nvd3 as dependency & to the layout file.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "jquery": "~1.11.1",
     "d3": "~3.4.8",
-    "neue": "dosomething/neue#~3.15.2"
+    "neue": "dosomething/neue#~3.15.2",
+    "nvd3": "~1.1.15-beta"
   }
 }

--- a/flasksite/templates/layout.html
+++ b/flasksite/templates/layout.html
@@ -7,6 +7,9 @@
 		<script type="text/javascript" src="/static/bower_components/jquery/dist/jquery.min.js" charset="utf-8"></script>
 		<link rel="stylesheet" href="/static/bower_components/epoch/epoch.0.3.5.min.css">
 		<script type="text/js" src="/static/bower_components/epoch/epoch.0.3.5.min.js"></script>
+		<script type="text/javascript" src="/static/bower_components/nvd3/nv.d3.min.js" charset="utf-8"></script>
+		<link rel="stylesheet" href="/static/bower_components/nvd3/nv.d3.min.css">
+
 		<meta charset="utf-8">
 	</head>
 	<body>


### PR DESCRIPTION
Adding [nvd3](https://github.com/novus/nvd3) as dependency. 

This allows for easy, reusable charting.
It's a library on top of d3 js, so we don't need to throw anything we've done away. 
